### PR TITLE
fix: sync initial date in add event dialog with selected date in week view

### DIFF
--- a/src/calendar/components/dialogs/add-event-dialog.tsx
+++ b/src/calendar/components/dialogs/add-event-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import React, { useEffect } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 
@@ -47,6 +48,13 @@ export function AddEventDialog({ children, startDate, startTime }: IProps) {
     onClose();
     form.reset();
   };
+
+  useEffect(() => {
+    form.reset({
+      startDate,
+      startTime,
+    });
+  }, [startDate, startTime, form.reset]);
 
   return (
     <Dialog open={isOpen} onOpenChange={onToggle}>


### PR DESCRIPTION
The add event dialog was showing an outdated initial date when navigating between dates using the header in week view. This commit ensures the dialog always reflects the currently selected date.